### PR TITLE
Bugfix/group permission

### DIFF
--- a/app/models/game.js
+++ b/app/models/game.js
@@ -441,8 +441,8 @@ GameSchema.statics.removeGroup = function(ids, groupId, callback)
 	}
 	return this.update(
 		query,
-		{$pull: {groups: {"groups.group" : groupId }}},
-		{multi: true},
+		{$pull: {groups: {group : groupId }}},
+		{multi: false},
 		callback
 	);
 };

--- a/app/models/game.js
+++ b/app/models/game.js
@@ -442,7 +442,7 @@ GameSchema.statics.removeGroup = function(ids, groupId, callback)
 	return this.update(
 		query,
 		{$pull: {groups: {group : groupId }}},
-		{multi: false},
+		{multi: true},
 		callback
 	);
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "SpringRollConnect",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"dependencies": {
 		"jquery": "*",
 		"bootstrap": "*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"private": true,
 	"devDependencies": {
 		"grunt": "^0.4.5",

--- a/project.json
+++ b/project.json
@@ -1,6 +1,6 @@
 {
 	"name": "SpringRollConnect",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"main": [
 		"src/plugins/jquery-search.js",
 		"src/widgets/*.js",


### PR DESCRIPTION
Fixed a bug where if you remove a group from a game, it removes all groups associated with that game. Basically it wipes the entire "groups" array.

The problem:

1) In version 1.3.11, go to Groups
2) Choose a group
3) Under games, delete a game
4) Go to the game that you deleted

Observe that all group permissions have been removed.

The group permission should only be removed from the specified group.

This change allows only the specified group to be removed from the game group privileges.