### PR TITLE
Rolling back to mongo 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
     db:
-        image: mongo:3
+        image: mongo:2
         expose:
             - "27017"
         ports:


### PR DESCRIPTION
The live version of SpringRoll connect depends on version 2 of
mongo. Our version of mongoose has some incompatibilities with mongo 3
so this should resolve that. Note: docker hub doesn't list mongo 2 but
it does indeed exist!