### PR TITLE
Bugfix/release documentation update

### DIFF
--- a/app/helpers/validators.js
+++ b/app/helpers/validators.js
@@ -27,6 +27,6 @@ module.exports = {
 	},
 	isBranch: function(value)
 	{
-		return /^[a-zA-Z0-9\_\-\/]*$/.test(value);
+		return /^[a-zA-Z0-9_\-\/]*[a-zA-Z0-9]$/.test(value);
 	}
 };

--- a/app/helpers/validators.js
+++ b/app/helpers/validators.js
@@ -24,5 +24,9 @@ module.exports = {
 	isBundleId: function(value)
 	{
 		return /^[a-zA-Z0-9\.\-]{3,}$/.test(value);
+	},
+	isBranch: function(value)
+	{
+		return /^[a-zA-Z0-9\_\-\/]*$/.test(value);
 	}
 };

--- a/app/routes/api/release.js
+++ b/app/routes/api/release.js
@@ -18,6 +18,7 @@ router.post('/:slug', function(req, res)
 	req.checkBody('status', 'Status must be one of: "dev", "qa", "stage", "prod"').isStatus();
 	req.checkBody('commitId', 'Commit ID must be a valid Git commit has').isCommit();
 	req.checkBody('token', 'Token is required').isToken();
+	req.checkBody('branch', 'Branch is required and must be a string').isBranch();
 	
 	if (req.body.verison)
 		req.checkBody('version', 'Not a properly formatted Semantic Version').isSemver();

--- a/app/views/docs.jade
+++ b/app/views/docs.jade
@@ -106,6 +106,10 @@ append content
 					strong warnUniqueCommit 
 					em (Boolean, default=false) 
 					p Warn on duplicate commitId
+				li
+					strong branch 
+					em (String) 
+					p The branch of the GIT commit
 		.well 
 			h4 POST 
 				strong /api/releases/clean


### PR DESCRIPTION
For POSTs to `api/release`, the `branch` parameter was required for the [front end](https://github.com/SpringRoll/SpringRollConnect/blob/master/app/views/games/releases.jade#L82) to display without error. I updated the documentation to include the parameter and added a validator to the route.