### PR TITLE
Fix missing branch bug

### DIFF
--- a/app/views/games/releases.jade
+++ b/app/views/games/releases.jade
@@ -73,10 +73,11 @@ append gameContent
 								else
 									include releases-controls
 									h4.release-data: strong Commit
-										a(href="#{game.repository}/commits/#{release.commitId}" data-toggle="tooltip" title="View Commit")=release.commitId.substr(0,7)
+										a(href="#{game.repository}/commits/#{release.commitId}" data-toggle="tooltip" title="View Commit")=' '+release.commitId.substr(0,7)
 
-									h4.release-data: strong Branch
-										a(href="#{game.repository}/browse?at=refs/heads/#{release.branch.replace('origin/', '')}" data-toggle="tooltip" title="View Branch")=release.branch
+									if release.branch
+										h4.release-data: strong Branch
+											a(href="#{game.repository}/browse?at=refs/heads/#{release.branch.replace('origin/', '')}" data-toggle="tooltip" title="View Branch")=' '+release.branch
 
 								.help-block.updated
 									span Updated


### PR DESCRIPTION
Previously, if the release didn't have a .branch value (not a field required in the model), the template would crash because there was no handling for it missing. Now, if it isn't there, it just doesn't display the UI element. 

I also added an extra whitespace character between the 'Branch'/'Commit' text and the values for those fields (it was missing in my dev environment, and the text was just running together).