### PR TITLE
Feature/token checking before game play

### DIFF
--- a/app/routes/embed.js
+++ b/app/routes/embed.js
@@ -1,13 +1,49 @@
 var router = require('express').Router();
+var log = require('../helpers/logger');
+var Group = require('../models/group');
 
 router.get('/:slug*', function(req, res)
 {
-	res.render('embed', 
-	{
-		isDebug: !!req.query.status ||
-			!!req.query.version || 
-			!!req.query.commitId
-	});
+  // check that the currently used token is still valid before even loading the page. This will prevent users from
+  // loading a game, only to receive a vague "Invalid API Request" message.
+  const token = req.query.token;
+
+  Group.findOne({ token : token })
+    .then(function(group) {
+      // if no group was found, redirect them back to the releases page with an appropriate message
+      if (group === null) {
+        log.warn('Failed to load group for token ' + token + ' when embedding game');
+        req.flash('error', 'Unable to view game. Unable to find group for API token ' + token);
+        res.redirect('/games/' + req.params.slug + '/releases');
+        return;
+      }
+
+      const now = new Date();
+
+      // if the token has expired, redirect the user back to the releases page with an appropriate message
+      if (group.tokenExpires !== null && group.tokenExpires < now) {
+        log.warn('Group ' + group.name + ' attempting to load game ' + req.params.slug + ' with expired token ' + token);
+        req.flash('error', 'Unable to view game. The ' + group.name + ' API token has expired.');
+        res.redirect('/games/' + req.params.slug + '/releases');
+        return;
+      }
+
+      // otherwise render the game
+      res.render('embed', {
+        isDebug: !!req.query.status ||
+          !!req.query.version || 
+            !!req.query.commitId
+      });
+    })
+    .catch(function(err) {
+      // if there was any uncaught exception, log it and still provide some sort of response.
+      log.error('Error fetching group for token ' + token);
+      log.error(err);
+
+      req.flash('error', 'Unable to view game.');
+      res.redirect('/games/' + req.params.slug + '/releases');
+      return;
+    });
 });
 
 module.exports = router;

--- a/app/views/games/releases.jade
+++ b/app/views/games/releases.jade
@@ -55,15 +55,15 @@ append gameContent
 								.release-title.clearfix
 									.btn-group.btn-flex-2
 										if release.version
-											a.btn.btn-sm.btn-default.external(data-toggle="tooltip" title="Release" href="//#{host}/embed/#{game.slug}?version=#{release.version}&controls=1&title=1&token=#{token}")
+											a.btn.btn-sm.btn-default(data-toggle="tooltip" title="Release" href="//#{host}/embed/#{game.slug}?version=#{release.version}&controls=1&title=1&token=#{token}")
 												span.glyphicon.glyphicon-play
-											a.btn.btn-sm.btn-default.external(data-toggle="tooltip" title="Debug" href="//#{host}/embed/#{game.slug}?version=#{release.version}&debug=1&controls=1&title=1&token=#{token}")
+											a.btn.btn-sm.btn-default(data-toggle="tooltip" title="Debug" href="//#{host}/embed/#{game.slug}?version=#{release.version}&debug=1&controls=1&title=1&token=#{token}")
 												span.glyphicon.glyphicon-wrench
 												span.glyphicon.glyphicon-play
 										else
-											a.btn.btn-sm.btn-default.external(data-toggle="tooltip" title="Release" href="//#{host}/embed/#{game.slug}?commitId=#{release.commitId}&controls=1&title=1&token=#{token}")
+											a.btn.btn-sm.btn-default(data-toggle="tooltip" title="Release" href="//#{host}/embed/#{game.slug}?commitId=#{release.commitId}&controls=1&title=1&token=#{token}")
 												span.glyphicon.glyphicon-play
-											a.btn.btn-sm.btn-default.external(data-toggle="tooltip" title="Debug" href="//#{host}/embed/#{game.slug}?commitId=#{release.commitId}&debug=1&controls=1&title=1&token=#{token}")
+											a.btn.btn-sm.btn-default(data-toggle="tooltip" title="Debug" href="//#{host}/embed/#{game.slug}?commitId=#{release.commitId}&debug=1&controls=1&title=1&token=#{token}")
 												span.glyphicon.glyphicon-wrench
 												span.glyphicon.glyphicon-play
 							.col-sm-9: .row: .col-sm-12


### PR DESCRIPTION
Cleaning up a long-standing UX issue. When loading the game embed page, SpringRollConnect would not check the token before loading the page. This would result in the page performing an API request to load the game, only to find out that the token was expired, but unable to provide a meaningful error message to users.

So, I've beefed up the logic for that route to provide better flash messaging to users and to improve logging in that situation as well.