### PR TITLE
Fix bug where token field would not be populated for read only users

### DIFF
--- a/app/models/game.js
+++ b/app/models/game.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var ObjectId = Schema.Types.ObjectId;
 var User = require('./user');
+var Group = require('./group');
 
 /**
  * The game model
@@ -340,8 +341,12 @@ GameSchema.methods.getAccess = function(user, callback) {
   // if there's a match with the current user
   this.groups.forEach(function(entry) {
     if (user.inGroup(entry.group) && entry.permission >= result.permission) {
-      result.token = entry.group.token;
-      result.permission = entry.permission;
+      // have to get the whole group object so we can get the token.
+      let validGroup = user.groups.find(function(groupId){
+        return groupId.equals(entry.group);
+      });
+      result.token = validGroup.token;
+      result.permission = validGroup.permission;
     }
   });
 

--- a/app/models/game.js
+++ b/app/models/game.js
@@ -324,31 +324,35 @@ GameSchema.methods.addGroup = function(ids, permissions, callback) {
  * @param  {mongoose.User} user The current user
  */
 GameSchema.methods.getAccess = function(user, callback) {
+  let isAdmin = false;
   var result = {
     permission: -1,
     token: null
   };
 
-  // Check for the user group's privilege
-  // if we're a producer or admin, use their settings first
-  if (user.privilege) {
+  // Check if the user is an admin, or in an admin group
+  // If they are, ignore further checks for specific game access
+  if (user.privilege === 2) {
     var group = user.groups[0];
     result.permission = user.privilege;
     result.token = group.token;
+    isAdmin = true;
   }
 
-  // Go through all the game groups to determine
-  // if there's a match with the current user
-  this.groups.forEach(function(entry) {
-    if (user.inGroup(entry.group) && entry.permission >= result.permission) {
-      // have to get the whole group object so we can get the token.
-      let validGroup = user.groups.find(function(groupId){
-        return groupId.equals(entry.group);
-      });
-      result.token = validGroup.token;
-      result.permission = validGroup.permission;
-    }
-  });
+  if(!isAdmin){
+    // Go through all the game groups to determine
+    // if there's a match with the current user
+    this.groups.forEach(function(entry) {
+      if (user.inGroup(entry.group) && entry.permission >= result.permission) {
+        // have to get the whole group object so we can get the token.
+        let validGroup = user.groups.find(function(groupId){
+          return groupId.equals(entry.group);
+        });
+        result.token = validGroup.token;
+        result.permission = validGroup.privilege;
+      }
+    });
+  }
 
   if (result == -1) {
     callback('Access denied', this, result);

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -202,7 +202,15 @@ UserSchema.methods.getGames = function(callback)
 UserSchema.methods.inGroup = function(group)
 {
 	return this.groups.find(function(g){
-		return g._id.equals(group._id);
+		// parse whether we've received the whole group object, or just the groupId itself
+		// this is SUPER bad practice, 
+		// but one more piece of duct tape on this garbage permissions system isnt going to matter much.
+		if (group._id){
+			return g._id.equals(group._id);
+		}
+		else {
+			return g._id.equals(group);
+		}
 	});
 };
 


### PR DESCRIPTION
So, if you were a read only user, and part of a read only group, `user.privilege` would equal 0. As a result, the first if-block in the getAccess function would be ignored. You'd move on to the forEach block, where two things would occur:

1. You would fail the if check because this block of code passes in **only the groupId** to `inGroup`, which compared it against the entire group object (yielding `false`). Then,
2. It would try to read the `.token` value from `this.groups[x]`, which is undefined because, as I said, the values in `this.groups` does not contain the whole group object.

That top level issue - `this.groups` not containing the whole group object - is a function of the way that the Game model stores its internal group objects. It stores them in the form:

```
{
    'group': [the mongo-internal-id of the Group object in the Group collection],
    '_id': [the mongo-interal-id of THIS object as part of the Game record],
    'privilege': [the permissions level for the group for THIS game in particular]
}
```
All of which ends with me putting a band-aid on this nonsense instead of trying to re-work the data model when quite frankly I want to throw the whole thing (that is, this permissions system) in the garbage.

Thoughts, critique, etc welcomed, and we should make sure to merge this or some other fix before we deploy this stuff to prod.