### PR TITLE
Bugfix/admin tokens

### DIFF
--- a/app/models/game.js
+++ b/app/models/game.js
@@ -437,6 +437,15 @@ GameSchema.methods.hasPermission = function(token, callback) {
         });
     })
     .then(function(groups) {
+      // first, check if the user is an admin (by looking at their user group). If so, they should have permissions on
+      // all games
+      for (let i = 0; i < groups.length; i++) {
+        if (groups[i].isUserGroup === true && groups[i].privilege === 2) {
+          callback(null, game);
+          return;
+        }
+      }
+
       const ids = groups.map(group => group._id.toString());
       const gameGroups = game.groups.map(entry => {
         if (entry.group._id) {

--- a/test/api/release.js
+++ b/test/api/release.js
@@ -106,5 +106,32 @@ describe('api/release', () => {
         .send(releaseParams);
       expect(postResponse.body.success).to.equal(false);
     });
+
+    it('should still allow an admin user to create a game, even if they do not have privileges on that game', async function() {
+      await dataMakers.makeGame('prod');
+      let gameResponse = await request.get('http://localhost:3000/api/games');
+
+      // make a admin level access token
+      let editor = await dataMakers.makeUser(2);
+      let token = await dataMakers.getUserToken(editor);
+      // get the game slug from the api response
+      let gameSlug = gameResponse.body.data[0].slug;
+
+      // make a new commit id for the new release
+      let commitId = dataMakers.makeRandomString(40);
+
+      // send the request
+      let releaseParams = {
+        status: 'dev',
+        commitId: commitId,
+        version: '1.0.0',
+        token: token
+      };
+
+      let postResponse = await request
+        .post(`http://localhost:3000/api/release/${gameSlug}`)
+        .send(releaseParams);
+      expect(postResponse.body.success).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
This PR allows admin users to create releases, even if they're not explicitly assigned to a particular game. I believe this was original functionality, but was lost during the 1.7.0 shuffle.