### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "devDependencies": {
     "@babel/cli": "^7.2.3",


### PR DESCRIPTION
There's actually been a bunch of changes since 1.7.0, so we're bumping and tagging so we can have everything in an acceptable state.