### PR TITLE
Making the is debug check more robust.

### DIFF
--- a/app/models/release.js
+++ b/app/models/release.js
@@ -233,12 +233,14 @@ ReleaseSchema.statics.getByGame = function(slug, options, callback) {
   );
 
   function addUrl(r) {
+    let isDebug = options.debug !== undefined && JSON.parse(options.debug) === true;
+
     r.url =
       r.game.location +
       '/' +
       r.commitId +
       '/' +
-      ((JSON.parse(options.debug) === true) ? 'debug' : 'release') +
+      (isDebug ? 'debug' : 'release') +
       (options.archive ? '.zip' : '/index.html');
   }
 


### PR DESCRIPTION
This particular line was failing when debug wasn't provided as a query
parameter because options.debug was undefined. This caused
JSON.parse(options.debug) to throw an error, because that's what
JSON.parse does in that case I guess?